### PR TITLE
test_has_media内のf-Stringsを取り除いた #15

### DIFF
--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -14,7 +14,7 @@ class TestAPI(unittest.TestCase):
         response = [{"user": None, "media": None}, {"user": None}]
         expectations = [True, False]
         for expectation, status in zip(expectations, response):
-            tweet = Mock(entities=f"{status}")
+            tweet = Mock(entities=status)
             actual = has_media(tweet)
             self.assertEqual(expectation, actual)
 


### PR DESCRIPTION
`has_media`内において、文字列に対する評価式から辞書キーに対する評価式にするためにf-Stringsを取り除いた。

詳しくは #15 を見てください。