### PR TITLE
タイムラインの取得やタイムラインのsince_idとmax_idを保存、取得するためのクラスの追加 #23

### DIFF
--- a/tests/test_timeline.py
+++ b/tests/test_timeline.py
@@ -1,0 +1,61 @@
+import unittest
+from unittest.mock import Mock
+
+from twissify.timeline import Timeline
+
+
+class TestTimeline(unittest.TestCase):
+    def test_home_timeline_api(self):
+        expectation_tweets = []
+        api = Mock(**{"home_timeline.return_value": expectation_tweets})
+        storage = None
+        timeline = Timeline(api, storage)
+        expectation_kwargs = {"count": 100,
+                              "since_id": 10,
+                              "max_id": 1}
+        actual = timeline.home_timeline(**expectation_kwargs)
+        self.assertEqual(expectation_tweets, actual)
+
+        api.home_timeline.assert_called_once_with(**expectation_kwargs)
+
+    def test_home_timeline_storage_create_ids(self):
+        expectation_tweets = [1]
+        api = Mock(**{"home_timeline.return_value": expectation_tweets})
+        storage = Mock()
+        timeline = Timeline(api, storage)
+        expectation_kwargs = {"count": 200,
+                              "since_id": 20,
+                              "max_id": 2}
+        actual = timeline.home_timeline(**expectation_kwargs)
+        self.assertEqual(expectation_tweets, actual)
+
+        storage.create_ids.assert_called_once_with("home_timeline",
+                                                   expectation_tweets)
+
+    def test_home_timeline_storage_update_ids(self):
+        expectation_tweets = [2, 3]
+        api = Mock(**{"home_timeline.return_value": expectation_tweets})
+        storage = Mock(**{"create_ids.side_effect": ValueError})
+        timeline = Timeline(api, storage)
+        expectation_kwargs = {"count": 300,
+                              "since_id": 30,
+                              "max_id": 3}
+        actual = timeline.home_timeline(**expectation_kwargs)
+        self.assertEqual(expectation_tweets, actual)
+
+        storage.update_ids.assert_called_once_with("home_timeline",
+                                                   expectation_tweets)
+
+    def test_get_home_timeline_ids(self):
+        expectation = "Success!"
+        api = None
+        storage = Mock(**{"get_ids.return_value": expectation})
+        timeline = Timeline(api, storage)
+        actual = timeline.get_home_timeline_ids
+        self.assertEqual(expectation, actual)
+
+        storage.get_ids.assert_called_once_with("home_timeline")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/twissify/timeline.py
+++ b/twissify/timeline.py
@@ -1,0 +1,59 @@
+class Timeline:
+    """タイムラインの取得とsince_idとmax_idを保存、取得するクラス"""
+    def __init__(self, api, storage):
+        """
+        Parameters
+        ----------
+        api : tweepy.api.API
+            tweepyでユーザー認証したTwitterAPIのラッパー
+        storage : TimelineIndexStorage
+            since_idとmax_idを保存するためのストレージ
+        """
+        self._api = api
+        self._storage = storage
+
+    def home_timeline(self, count, since_id=None, max_id=None):
+        """ホームタイムライン上のツイートを取得する
+
+        Parameters
+        ----------
+        count : int
+            取得するツイートの総数。最大は200
+        since_id : int, default None
+            タイムラインを取得し始めるツイートID
+        max_id : int, default None
+            タイムラインを取得し終えるツイートID
+
+        Returns
+        -------
+        tweets : tweepy.models.ResultSet
+            ホームタイムライン上のツイート
+
+        Notes
+        -----
+        `since_id`で指定した値を超えるIDを持つツイートを取得する。
+        `max_id`で指定した値以下のIDを持つツイートを取得する。
+        両方指定しなければ、最新のタイムラインを取得する。
+        """
+        tweets = self._api.home_timeline(count=count, since_id=since_id,
+                                         max_id=max_id)
+        timeline_name = self.home_timeline.__name__
+
+        if tweets != []:
+            try:
+                self._storage.create_ids(timeline_name, tweets)
+            except ValueError:
+                self._storage.update_ids(timeline_name, tweets)
+
+        return tweets
+
+    @property
+    def get_home_timeline_ids(self):
+        """前回のsince_idとmax_idを保持するオブジェクトを取得する
+
+        Returns
+        -------
+        TimelineIndex or None
+            since_idとmax_idを保持するオブジェクト。存在しなければNone
+        """
+        return self._storage.get_ids("home_timeline")


### PR DESCRIPTION
ホームタイムラインに対してのみを追加した。今後、必要に応じて増やしていく予定。

現在の`Timeline`クラスが行えることは以下の2つ。
- ホームタイムラインの取得する + ホームタイムラインの`since_id`と`max_id`を保存する
- ホームタイムラインの`since_id`と`max_id`を取得する


詳しくは #23 を見てください。