### PR TITLE
テスト環境からPython3.5を削除 #27

### DIFF
--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.5, 3.6, 3.7, 3.8]
+        python-version: [3.6, 3.7, 3.8]
 
     steps:
     - uses: actions/checkout@v2


### PR DESCRIPTION
NumpyがPython3.5に対応しなくなったためテスト環境から除いた。

詳しくは #27 を見てください。