### PR TITLE
プロパティ名の変更とプロパティをdocstringに追加 #35

### DIFF
--- a/tests/test_timeline.py
+++ b/tests/test_timeline.py
@@ -46,12 +46,12 @@ class TestTimeline(unittest.TestCase):
         storage.update_ids.assert_called_once_with("home_timeline",
                                                    expectation_tweets)
 
-    def test_get_home_timeline_ids(self):
+    def test_home_timeline_ids(self):
         expectation = "Success!"
         api = None
         storage = Mock(**{"get_ids.return_value": expectation})
         timeline = Timeline(api, storage)
-        actual = timeline.get_home_timeline_ids
+        actual = timeline.home_timeline_ids
         self.assertEqual(expectation, actual)
 
         storage.get_ids.assert_called_once_with("home_timeline")

--- a/twissify/timeline.py
+++ b/twissify/timeline.py
@@ -1,5 +1,11 @@
 class Timeline:
-    """タイムラインの取得と ``since_id`` と ``max_id`` を保存、取得するクラス"""
+    """タイムラインの取得と ``since_id`` と ``max_id`` を保存、取得するクラス
+
+    Attributes
+    ーーーーーー
+    home_timeline_ids : TimelineIndex or None
+        ホームタイムラインの ``since_id`` と ``max_id`` を保持するオブジェクト
+    """
     def __init__(self, api, storage):
         """
         Parameters

--- a/twissify/timeline.py
+++ b/twissify/timeline.py
@@ -48,7 +48,7 @@ class Timeline:
         return tweets
 
     @property
-    def get_home_timeline_ids(self):
+    def home_timeline_ids(self):
         """前回の ``since_id`` と ``max_id`` を保持するオブジェクトを取得する
 
         Returns


### PR DESCRIPTION
`Timeline`クラスにおいて、
`get_home_timeline_ids`を`home_timeline_ids`に変更した。
`home_timeline_ids`をdocstringのAttributesに記載した。

詳しくは #35 を見てください。