### PR TITLE
`Timeline.home_timeline`の内部処理の一部を`Timeline.save_timeline_ids`として分離 #38

### DIFF
--- a/tests/test_timeline.py
+++ b/tests/test_timeline.py
@@ -11,11 +11,13 @@ class TestTimeline(unittest.TestCase):
         storage = None
         timeline = Timeline(api, storage)
         timeline.save_timeline_ids = Mock()
-        expectation = {"count": 100, "since_id": 20, "max_id": 5}
-        actual = timeline.home_timeline(**expectation)
+        expectation_kwargs = {"count": 100,
+                              "since_id": 10,
+                              "max_id": 1}
+        actual = timeline.home_timeline(**expectation_kwargs)
         self.assertEqual(actual, expectation_tweets)
 
-        api.home_timeline.assert_called_once_with(**expectation)
+        api.home_timeline.assert_called_once_with(**expectation_kwargs)
         timeline.save_timeline_ids.assert_called_once_with("home_timeline",
                                                            expectation_tweets)
 

--- a/twissify/timeline.py
+++ b/twissify/timeline.py
@@ -43,15 +43,24 @@ class Timeline:
         """
         tweets = self._api.home_timeline(count=count, since_id=since_id,
                                          max_id=max_id)
-        timeline_name = self.home_timeline.__name__
+        self.save_timeline_ids(self.home_timeline.__name__, tweets)
+        return tweets
 
+    def save_timeline_ids(self, timeline_name, tweets):
+        """タイムラインの ``since_id`` と ``max_id`` を保存する
+
+        Parameters
+        ----------
+        timeline_name : str
+            タイムライン名
+        tweets : tweepy.models.ResultSet
+            タイムライン上のツイート
+        """
         if tweets != []:
             try:
                 self._storage.create_ids(timeline_name, tweets)
             except ValueError:
                 self._storage.update_ids(timeline_name, tweets)
-
-        return tweets
 
     @property
     def home_timeline_ids(self):


### PR DESCRIPTION
`Timeline.home_timeline`内の`since_id`と`max_id`を保存する処理を`Timeline.save_timeline_ids`として置き換えた。
この変更に伴い、テスト関数も`home_timeline`と`save_timeline_ids`に対するコードとして分けることができた。

詳しくは #38 を見てください。