### PR TITLE
パッチに与えた`side_effect`や`return_value`の値を関数内で流用するように変更 #45

### DIFF
--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1,3 +1,4 @@
+import copy
 import numpy as np
 import unittest
 from unittest.mock import Mock, patch
@@ -46,8 +47,8 @@ class TestAPI(unittest.TestCase):
 
     @patch("twissify.api.is_retweet",
            side_effect=[True, False, True, False, False])
-    def test_filter_retweets(self, _):
-        bools = [True, False, True, False, False]
+    def test_filter_retweets(self, is_retweet):
+        bools = list(copy.copy(is_retweet.side_effect))
         tweets = [Mock() for _ in bools]
         actuals = filter_retweets(tweets)
         expectations = [tweet for tweet, bool in zip(tweets, bools)
@@ -64,8 +65,8 @@ class TestAPI(unittest.TestCase):
 
     @patch("twissify.api.is_photo",
            side_effect=[True, False, True, False, False])
-    def test_extract_photo_tweets(self, _):
-        bools = [True, False, True, False, False]
+    def test_extract_photo_tweets(self, is_photo):
+        bools = list(copy.copy(is_photo.side_effect))
         tweets = [Mock() for _ in bools]
         actuals = extract_photo_tweets(tweets)
         expectations = [tweet for tweet, bool in zip(tweets, bools) if bool]
@@ -98,7 +99,7 @@ class TestAPI(unittest.TestCase):
     @patch("twissify.api.is_retweet",
            side_effect=[True, False, False, True, True])
     def test_extract_retweets_origin(self, is_retweet):
-        bools = [True, False, False, True, True]
+        bools = list(copy.copy(is_retweet.side_effect))
         statuses = list(range(0, len(bools)))
         tweets = [Mock(retweeted_status=status) for status in statuses]
         actuals = extract_retweets_origin(tweets)

--- a/tests/test_image.py
+++ b/tests/test_image.py
@@ -11,10 +11,10 @@ class TestImage(unittest.TestCase):
     def test_load_image_url(self, requests_get, open_image_binary):
         url = "url"
         expectations = [(None, 199),
-                        ("ImageFile", 200),
+                        (open_image_binary.return_value, 200),
                         (None, 201)]
         expectation_requests_get = url
-        expectation_oib = "bytes"
+        expectation_oib = requests_get.return_value.content
 
         for expectation in expectations:
             requests_get.return_value.status_code = expectation[1]
@@ -29,9 +29,9 @@ class TestImage(unittest.TestCase):
     @patch("io.BytesIO", return_value="bytes")
     def test_open_image_binary(self, io_BytesIO, Image_open):
         string = "test"
-        expectation = "Success!"
+        expectation = Image_open.return_value
         expectation_io_BytesIO = string
-        expectation_Image_open = "bytes"
+        expectation_Image_open = io_BytesIO.return_value
         actual = open_image_binary(string)
         io_BytesIO.assert_called_once_with(expectation_io_BytesIO)
         Image_open.assert_called_once_with(expectation_Image_open)


### PR DESCRIPTION
test_api.pyでは`side_effect`、test_image.pyでは`return_value`の値を関数内で流用するように変更した。

詳しくは #45 を見てください。