### PR TITLE
`Timeline`から`APIWrapper`に変更 #47

### DIFF
--- a/tests/test_api_wrapper.py
+++ b/tests/test_api_wrapper.py
@@ -1,23 +1,24 @@
 import unittest
 from unittest.mock import Mock
 
+from twissify.api_wrapper import APIWrapper
+
 from test_tables import test_ids
-from twissify.timeline import Timeline
 
 
-class TestTimeline(unittest.TestCase):
+class TestAPIWrapper(unittest.TestCase):
     def test_home_timeline(self):
         expectation_tweets = [1, 2, 3]
         timeline_name = "home_timeline"
         expectation = {timeline_name: expectation_tweets}
         api = Mock(**{"home_timeline.return_value": expectation_tweets})
         storage = None
-        timeline = Timeline(api, storage)
+        apiw = APIWrapper(api, storage)
         expectation_kwargs = {"count": 100,
                               "since_id": 10,
                               "max_id": 1}
-        actual_tweets = timeline.home_timeline(**expectation_kwargs)
-        actual = timeline._tweets
+        actual_tweets = apiw.home_timeline(**expectation_kwargs)
+        actual = apiw._tweets
         self.assertEqual(actual_tweets, expectation_tweets)
         self.assertEqual(actual, expectation)
 
@@ -25,9 +26,9 @@ class TestTimeline(unittest.TestCase):
         tweets = []
         api = None
         storage = Mock()
-        timeline = Timeline(api, storage)
+        apiw = APIWrapper(api, storage)
         timeline_name = "home_timeline"
-        timeline.save_timeline_ids(timeline_name, tweets)
+        apiw.save_timeline_ids(timeline_name, tweets)
 
         storage.create_ids.assert_not_called()
         storage.update_ids.assert_not_called()
@@ -36,9 +37,9 @@ class TestTimeline(unittest.TestCase):
         tweets = [1]
         api = None
         storage = Mock()
-        timeline = Timeline(api, storage)
+        apiw = APIWrapper(api, storage)
         timeline_name = "home_timeline"
-        timeline.save_timeline_ids(timeline_name, tweets)
+        apiw.save_timeline_ids(timeline_name, tweets)
 
         storage.create_ids.assert_called_once_with(timeline_name, tweets)
 
@@ -46,9 +47,9 @@ class TestTimeline(unittest.TestCase):
         tweets = [2, 3]
         api = None
         storage = Mock(**{"create_ids.side_effect": ValueError})
-        timeline = Timeline(api, storage)
+        apiw = APIWrapper(api, storage)
         timeline_name = "home_timeline"
-        timeline.save_timeline_ids(timeline_name, tweets)
+        apiw.save_timeline_ids(timeline_name, tweets)
 
         storage.update_ids.assert_called_once_with(timeline_name, tweets)
 
@@ -56,8 +57,8 @@ class TestTimeline(unittest.TestCase):
         expectation = "Success!"
         api = None
         storage = Mock(**{"get_ids.return_value": expectation})
-        timeline = Timeline(api, storage)
-        actual = timeline.home_timeline_ids
+        apiw = APIWrapper(api, storage)
+        actual = apiw.home_timeline_ids
         self.assertEqual(expectation, actual)
 
         storage.get_ids.assert_called_once_with("home_timeline")
@@ -68,13 +69,13 @@ class TestTimeline(unittest.TestCase):
         timelines_tweets = test_ids(return_values, 3)
         api = Mock(**dict(zip(return_values, timelines_tweets)))
         storage = None
-        with Timeline(api, storage) as tl:
-            tl.save_timeline_ids = Mock()
-            tl.home_timeline(100)
+        with APIWrapper(api, storage) as apiw:
+            apiw.save_timeline_ids = Mock()
+            apiw.home_timeline(100)
 
         for name, tweets in zip(names, timelines_tweets):
             with self.subTest(names=names, tweets=tweets):
-                tl.save_timeline_ids.assert_any_call(name, tweets)
+                apiw.save_timeline_ids.assert_any_call(name, tweets)
 
 
 if __name__ == "__main__":

--- a/tests/test_api_wrapper.py
+++ b/tests/test_api_wrapper.py
@@ -7,6 +7,31 @@ from test_tables import test_ids
 
 
 class TestAPIWrapper(unittest.TestCase):
+    def test__init__(self):
+        class TestAPI:
+            def __init__(self, a):
+                self._test_attribute = a
+
+            def test_method(self, b):
+                return b
+
+            def home_timeline(self):
+                return 1
+
+        names = {"_test_attribute", "test_method", "__weakref__", "__new__"}
+        api = TestAPI(2)
+        storage = None
+        apiw = APIWrapper(api, storage)
+        for attribute_name in dir(api):
+            with self.subTest(attribute_name=attribute_name):
+                api_attribute = str(getattr(api, attribute_name))
+                apiw_attribute = str(getattr(apiw, attribute_name))
+
+                if attribute_name in names:
+                    self.assertEqual(api_attribute, apiw_attribute)
+                else:
+                    self.assertNotEqual(api_attribute, apiw_attribute)
+
     def test_home_timeline(self):
         expectation_tweets = [1, 2, 3]
         timeline_name = "home_timeline"

--- a/twissify/api_wrapper.py
+++ b/twissify/api_wrapper.py
@@ -19,6 +19,15 @@ class APIWrapper:
         self._storage = storage
         self._tweets = {}
 
+        apiw_method_names = filter_special_methods(APIWrapper)
+        api_attribute_names = filter_special_methods(api)
+
+        for attribute_name in (api_attribute_names - apiw_method_names):
+            try:
+                setattr(self, attribute_name, getattr(api, attribute_name))
+            except AttributeError:
+                pass
+
     def home_timeline(self, count, since_id=None, max_id=None):
         """ホームタイムライン上のツイートを取得する
 
@@ -81,3 +90,19 @@ class APIWrapper:
         "各タイムラインの ``since_id`` と ``max_id`` を保存する"
         for timeline_name, tweets in self._tweets.items():
             self.save_timeline_ids(timeline_name, tweets)
+
+
+def filter_special_methods(obj):
+    """特殊メソッド以外の属性名の集合を取得する
+
+    Parameters
+    ----------
+    obj : object
+
+    Returns
+    -------
+    set
+        特殊メソッドを取り除いた属性の集合
+    """
+    return {method for method in dir(obj)
+            if not (method.startswith("__") and method.endswith("__"))}

--- a/twissify/api_wrapper.py
+++ b/twissify/api_wrapper.py
@@ -1,5 +1,5 @@
-class Timeline:
-    """タイムラインの取得と ``since_id`` と ``max_id`` を保存、取得するクラス
+class APIWrapper:
+    """TwitterAPIのラッパーのラッパー
 
     Attributes
     ーーーーーー


### PR DESCRIPTION
クラス名とファイル名を変更し、正しい属性を持っているかのテストを追加した。

詳しくは #47 を見てください。