### PR TITLE
`APIWrapper`クラスの`home_timeline_ids`メソッドの返り値を`namedtuple`に変更 #49

### DIFF
--- a/tests/test_api_wrapper.py
+++ b/tests/test_api_wrapper.py
@@ -81,12 +81,38 @@ class TestAPIWrapper(unittest.TestCase):
     def test_home_timeline_ids(self):
         expectation = "Success!"
         api = None
-        storage = Mock(**{"get_ids.return_value": expectation})
+        storage = None
         apiw = APIWrapper(api, storage)
+        apiw._get_ids = Mock(return_value=expectation)
         actual = apiw.home_timeline_ids
         self.assertEqual(expectation, actual)
 
-        storage.get_ids.assert_called_once_with("home_timeline")
+        apiw._get_ids.assert_called_once_with("home_timeline")
+
+    def test__get_ids_not_exist_record(self):
+        expectation_ids = None
+        expectation_name = "test_timeline"
+        api = None
+        storage = Mock(**{"get_ids.return_value": expectation_ids})
+        apiw = APIWrapper(api, storage)
+        actual = apiw._get_ids(expectation_name)
+        self.assertEqual(expectation_ids, actual.since_id)
+        self.assertEqual(expectation_ids, actual.max_id)
+
+        storage.get_ids.assert_called_once_with(expectation_name)
+
+    def test__get_ids_exist_record(self):
+        expectation_ids = {"since_id": 10, "max_id": 20}
+        ids = Mock(**expectation_ids)
+        expectation_name = "test_timeline"
+        api = None
+        storage = Mock(**{"get_ids.return_value": ids})
+        apiw = APIWrapper(api, storage)
+        actual = apiw._get_ids(expectation_name)
+        self.assertEqual(expectation_ids["since_id"], actual.since_id)
+        self.assertEqual(expectation_ids["max_id"], actual.max_id)
+
+        storage.get_ids.assert_called_once_with(expectation_name)
 
     def test_with_save_timeline_ids_called_timelines(self):
         names = ["home_timeline"]

--- a/twissify/api_wrapper.py
+++ b/twissify/api_wrapper.py
@@ -1,3 +1,6 @@
+from collections import namedtuple
+
+
 class APIWrapper:
     """TwitterAPIのラッパーのラッパー
 
@@ -81,7 +84,15 @@ class APIWrapper:
         TimelineIndex or None
             ``since_id`` と ``max_id`` を保持するオブジェクト。存在しなければ ``None``
         """
-        return self._storage.get_ids("home_timeline")
+        return self._get_ids("home_timeline")
+
+    def _get_ids(self, name):
+        TimelineIndex = namedtuple("TimelineIndex", ["since_id", "max_id"])
+        ids = self._storage.get_ids(name)
+        if ids is None:
+            return TimelineIndex(since_id=None, max_id=None)
+        else:
+            return TimelineIndex(since_id=ids.since_id, max_id=ids.max_id)
 
     def __enter__(self):
         return self


### PR DESCRIPTION
詳しくは #49 を見てください。